### PR TITLE
add minicheck as a fact-checking model

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Much prior work in this area has been done. For some of the top papers in this a
 * [TRUE: Re-evaluating Factual Consistency Evaluation](https://arxiv.org/pdf/2204.04991.pdf)
 * [TrueTeacher: Learning Factual Consistency Evaluation with Large Language Models](https://browse.arxiv.org/pdf/2305.11171v1.pdf)
 * [ALIGNSCORE: Evaluating Factual Consistency with A Unified Alignment Function](https://arxiv.org/pdf/2305.16739.pdf)
+* [MiniCheck: Efficient Fact-Checking of LLMs on Grounding Documents](https://arxiv.org/pdf/2404.10774)
 
 For a very comprehensive list, please see here - https://github.com/EdinburghNLP/awesome-hallucination-detection. The methods described in the following section use protocols established in those papers, amongst many others.
 


### PR DESCRIPTION
Add MiniCheck as a fact-checking model.

See fact-checking models performance [leaderboard](https://llm-aggrefact.github.io). MiniCheck is the SOTA fact-checking model, significantly outperforming models such as SummaC and Alignscore.